### PR TITLE
fix: update mingo imports for v7 compatibility

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -45,7 +45,6 @@ import require$$1$6 from 'console';
 import require$$1$7 from 'url';
 import require$$3$1 from 'zlib';
 import require$$0$c from 'diagnostics_channel';
-import 'mingo/init/system';
 
 // We use any as a valid input type
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -104200,6 +104199,11 @@ class Query extends Query$1 {
     super(condition, makeOpts(options));
   }
 }
+class Aggregator extends Aggregator$1 {
+  constructor(pipeline, options) {
+    super(pipeline, makeOpts(options));
+  }
+}
 
 /**
  * Filters and groups delivery items based on a specified query.
@@ -104265,7 +104269,7 @@ const buildStreams = ({ nodes, group }) => {
     let groupNodes = [];
     if (group.groupByField !== undefined) {
         info(`${group.name} - Processing group by field: ${group.groupByField}`);
-        const agg = new Aggregator$1([
+        const agg = new Aggregator([
             { $group: { _id: `$${group.groupByField}`, nodes: { $push: '$$ROOT' } } }
         ]);
         const aggResult = agg.run(nodes);
@@ -105059,7 +105063,7 @@ const groupNodesByField = ({ nodes, group }) => {
     }
     if (group.groupByField !== undefined) {
         info(`${group.name} - Groupping nodes by field: ${group.groupByField}`);
-        const agg = new Aggregator$1([
+        const agg = new Aggregator([
             { $group: { _id: `$${group.groupByField}`, nodes: { $push: '$$ROOT' } } }
         ]);
         const aggResult = agg.run(nodes);

--- a/src/metrics/buildGroup.ts
+++ b/src/metrics/buildGroup.ts
@@ -1,7 +1,6 @@
 import * as core from '@actions/core'
 
 import { Query } from 'mingo'
-import 'mingo/init/system'
 
 import { DeliveryItem, ConfigGroup } from '../types/index.js'
 

--- a/src/metrics/buildStreams.ts
+++ b/src/metrics/buildStreams.ts
@@ -1,9 +1,7 @@
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 import * as core from '@actions/core'
 
-import { Query } from 'mingo'
-import { Aggregator } from 'mingo/aggregator'
-import 'mingo/init/system'
+import { Query, Aggregator } from 'mingo'
 
 import { DeliveryItem, ConfigGroup, MetricStream } from '../types/index.js'
 

--- a/src/timelineMetrics/filterNodesByQuery.ts
+++ b/src/timelineMetrics/filterNodesByQuery.ts
@@ -1,7 +1,6 @@
 import * as core from '@actions/core'
 
 import { Query } from 'mingo'
-import 'mingo/init/system'
 
 import { ConfigTimelineGroup, DeliveryItem } from '../types/index.js'
 

--- a/src/timelineMetrics/groupNodesByField.ts
+++ b/src/timelineMetrics/groupNodesByField.ts
@@ -1,7 +1,6 @@
 import * as core from '@actions/core'
 
-import { Aggregator } from 'mingo/aggregator'
-import 'mingo/init/system'
+import { Aggregator } from 'mingo'
 
 import {
   DeliveryItem,


### PR DESCRIPTION
## Summary

Fixes runtime error when running the action with mingo 7.x:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './init/system' is not defined by "exports" in mingo/package.json
```

### Changes

- Removed `import 'mingo/init/system'` from 4 files — this entry point was removed in mingo 7
- Changed `import { Aggregator } from 'mingo/aggregator'` → `import { Aggregator } from 'mingo'` to get the version with all operators pre-loaded (mingo 7 includes all operators in the main export)

### Testing

- `npx local-action . src/main.ts .env` runs successfully end-to-end (18 dashboard views generated)
- All 61 unit tests pass
- Lint and format clean